### PR TITLE
Display post feed below the Compose widget

### DIFF
--- a/apps/builddao/widget/Feed.jsx
+++ b/apps/builddao/widget/Feed.jsx
@@ -187,7 +187,6 @@ return (
                   options: {
                     limit: 10,
                     order: "desc",
-                    accountId: context.accountId
                   },
                   cacheOptions: {
                     ignoreCache: true


### PR DESCRIPTION
- Removed AccountID option from the feed to display all posts from a selected feed.