### PR TITLE
Support our own notifications

### DIFF
--- a/apps/old/widget/Notification/NotificationRolesSelector.jsx
+++ b/apps/old/widget/Notification/NotificationRolesSelector.jsx
@@ -83,6 +83,10 @@ const createNotificationsData = () => {
     }
   });
   const uniqueMembersArray = [...new Set(membersToNotify)];
+  const item = {
+    type: "social",
+    path: `${context.accountId}/post/main`,
+  };
   const notification = {
     [accountId]: {
       index: {
@@ -91,14 +95,10 @@ const createNotificationsData = () => {
             return {
               key: account,
               value: {
+                type: `${config_account}/proposal/create`,
+                item,
                 message: message,
-                params: {
-                  daoId: daoId,
-                  tab: "proposals",
-                  page: "proposal",
-                },
-                type: "buildhub/custom",
-                widget: "${config_account}/widget/home",
+                widget: `${config_account}/widget/Index?page=activity&tab=proposals&daoId=${daoId}`,
               },
             };
           }),

--- a/apps/old/widget/Proposals.jsx
+++ b/apps/old/widget/Proposals.jsx
@@ -102,7 +102,7 @@ const NotificationModal = () => {
         onOpenChange={() => {}}
         hideCloseBtn={true}
       >
-        <div className="ndc-card d-flex flex-column gap-3 p-4">
+        <div className="d-flex flex-column gap-3 p-4">
           Do you want to notify proposer: {proposer} about the vote?
           <div className="d-flex gap-3 justify-content-end">
             <Button
@@ -144,6 +144,10 @@ const NotificationModal = () => {
 
 const handleVote = ({ action, proposalId, proposer, showNotification }) => {
   const customAction = action.replace("Vote", "");
+  const item = {
+    type: "social",
+    path: `${context.accountId}/post/main`,
+  };
   const notification = {
     [accountId]: {
       index: {
@@ -151,13 +155,10 @@ const handleVote = ({ action, proposalId, proposer, showNotification }) => {
           {
             key: proposer,
             value: {
+              type: `${config_account}/proposal/vote`,
+              item,
               message: `${accountId} voted to ${customAction} your proposal for ${daoId} (Proposal ID: ${proposalId})`,
-              params: {
-                daoId: daoId,
-                proposalId: proposalId,
-              },
-              type: "custom",
-              widget: "${config_account}/widget/Proposals",
+              widget: `${config_account}/widget/Index?page=activity&tab=proposals&daoId=${daoId}&proposalId=${proposalId}}`,
             },
           },
         ]),

--- a/apps/old/widget/components/ProposalCard.jsx
+++ b/apps/old/widget/components/ProposalCard.jsx
@@ -657,7 +657,7 @@ function renderFooter({ totalVotes, votes, comments, daoId, proposal }) {
       icon: "bi bi-share",
       widget: "Common.Modals.Share",
       props: {
-        url: `https://near.org/${config_account}/widget/Proposals?daoId=${daoId}&proposalId=${
+        url: `https://www.nearbuilders.org/${config_account}/widget/Index?page=activity&tab=proposals&daoId=${daoId}&proposalId=${
           proposalData.id
         }${props.dev ? "&dev=true" : ""}`,
         text: "Explore this new proposal from our DAO! Your support and feedback are essential as we work towards a decentralized future. Review the details and join the discussion here:",


### PR DESCRIPTION
Resolves #293 
Instead of using custom notifications, which is supported on near.org (but contains quite a few bugs) and isn't supported on near.social, I thought of adding our own index like `buildhub.near/{{feature}}/{{action}}`.
Because now we have our own notifications page in gateway, where we can easily support it.
Eg: for proposal, it will be `buildhub.near/proposal/vote`, `buildhub.near/proposal/create`, similarly we can have it for events, and other features. We can have "Approve", "Reject", "View", all these different actions for different type of feature and actions.
@elliotBraem what do you think of the idea and structure? if you agree, I will continue to add further changes to the PR